### PR TITLE
Make it support requests with query params for redirects

### DIFF
--- a/lib/Plack/Middleware/Rewrite.pm
+++ b/lib/Plack/Middleware/Rewrite.pm
@@ -31,8 +31,7 @@ sub call {
 		push @$res, [] if @$res < 3;
 
 		if ( $res->[0] =~ /\A3[0-9][0-9]\z/ ) {
-			my $req_base = Plack::Request->new( $env )->uri;
-			my $abs_dest = URI->new_abs( $_, $req_base );
+			my $abs_dest = Plack::Request->new( $env )->uri;
 			Plack::Util::header_set( $res->[1], Location => $abs_dest );
 		}
 

--- a/t/rewrite.t
+++ b/t/rewrite.t
@@ -56,6 +56,12 @@ test_psgi app => $app, client => sub {
 	is $res->header( 'Location' ), 'http://localhost/bar/', '... and produce the right Location';
 	ok !$res->content, '... and prevent execution of the wrapped app';
 
+	$req = GET 'http://localhost/foo?q=baz';
+	$res = $cb->( $req );
+	is $res->code, 301, 'Redirects change the status';
+	is $res->header( 'Location' ), 'http://localhost/bar/?q=baz', '... and produce the right Location';
+	ok !$res->content, '... and prevent execution of the wrapped app';
+
 	$req = GET 'http://localhost/die';
 	$res = $cb->( $req );
 	is $res->code, 404, 'Responses can be wholly fabricated';


### PR DESCRIPTION
The ->uri method already returns the abs URI and ensures to keep query
params (if avail) for the new location. All test pass (including the
this use case).
